### PR TITLE
fix: temporarily update the patches to the launcher

### DIFF
--- a/pkg_packagekit_package.go.patch
+++ b/pkg_packagekit_package.go.patch
@@ -1,0 +1,28 @@
+diff --git a/pkg/packagekit/package.go b/pkg/packagekit/package.go
+index bd88b6d..f3f821d 100644
+--- a/pkg/packagekit/package.go
++++ b/pkg/packagekit/package.go
+@@ -3,14 +3,15 @@ package packagekit
+ // PackageOptions is the superset of all packaging options. Not all
+ // packages will support all options.
+ type PackageOptions struct {
+-	Identifier string // What is the identifier? (eg: kolide-app)
+-	Name       string // What's the name for this package (eg: launcher)
+-	Title      string // MacOS app bundle only -- the title displayed during installation
+-	Root       string // source directory to package
+-	Scripts    string // directory of packaging scripts (postinst, prerm, etc)
+-	Version    string // package version
+-	VersionNum int    // package version in numeric format. used to create comparable windows registry keys
+-	FlagFile   string // Path to the flagfile for configuration
++	Identifier    string // What is the identifier? (eg: kolide-app)
++	Name          string // What's the name for this package (eg: launcher)
++	Title         string // MacOS app bundle only -- the title displayed during installation
++	Root          string // source directory to package
++	Scripts       string // directory of packaging scripts (postinst, prerm, etc)
++	Version       string // package version
++	VersionNum    int    // package version in numeric format. used to create comparable windows registry keys
++	FlagFile      string // Path to the flagfile for configuration
++	ContainerTool string // Name of container orchestration system to use (docker, podman)
+ 
+ 	DisableService bool // Whether to install a system service in a disabled state
+ 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -52,7 +52,10 @@ test -f 1722.diff || curl -LO https://patch-diff.githubusercontent.com/raw/kolid
 echo ""
 echo ">> patching launcher ..."
 cd launcher
-patch -p1 <../1722.diff
+patch -p1 <../1722.diff || true
+
+echo ">> patching launcher/pkg/packagekit/package.go ..."
+patch -p1 <../../pkg_packagekit_package.go.patch
 
 echo ""
 echo ">> building package-builder ..."


### PR DESCRIPTION
This is a temporary fix to align the patch to the Launcher's `pkg/packagekit/package.go`  file.

See #1 